### PR TITLE
Task front end

### DIFF
--- a/src/app/shared/error-toasters/general-message-error/general-message-error.component.ts
+++ b/src/app/shared/error-toasters/general-message-error/general-message-error.component.ts
@@ -8,5 +8,7 @@ import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material';
 export class GeneralMessageErrorComponent {
   constructor(
     public snackBarRef: MatSnackBarRef<GeneralMessageErrorComponent>,
-    @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
+    @Inject(MAT_SNACK_BAR_DATA) public data: any) {
+      setTimeout(() => this.snackBarRef.dismiss(), 5000)
+    }
 }

--- a/src/app/shared/error-toasters/general-message-error/general-message-error.component.ts
+++ b/src/app/shared/error-toasters/general-message-error/general-message-error.component.ts
@@ -9,6 +9,6 @@ export class GeneralMessageErrorComponent {
   constructor(
     public snackBarRef: MatSnackBarRef<GeneralMessageErrorComponent>,
     @Inject(MAT_SNACK_BAR_DATA) public data: any) {
-      setTimeout(() => this.snackBarRef.dismiss(), 5000)
+      setTimeout(() => this.snackBarRef.dismiss(), 5000);
     }
 }


### PR DESCRIPTION
### Summary:

Makes error message displayed close after 5 seconds.


### Changes Made:

* Added delay in the constructor for error message display

### Effects of changes:

![CATcher-error-delay](https://user-images.githubusercontent.com/70463178/146348425-f01cef26-5ea0-46b9-9c4f-f9ed586dd8d2.gif)
